### PR TITLE
UserDefaultsを用いてphonesの入れ替えと削除のデータを保存可能にした

### DIFF
--- a/swiftuiTest/listReplacementView.swift
+++ b/swiftuiTest/listReplacementView.swift
@@ -52,11 +52,17 @@ struct listReplacementView: View {
                     .onMove(perform: phoneReplace)
                     .onDelete(perform: phoneDelete)
                 }
-                
-                
             }
+            .listStyle(GroupedListStyle())
             .navigationBarTitle("動作可能なリスト", displayMode: .inline)
             .navigationBarItems(trailing: EditButton())
+        }
+        // View表示の時にUserDefaultsからデータを呼び出す
+        .onAppear() {
+            guard let phoneItem = UserDefaults.standard.array(forKey: "phoneRow") as? [String] else {
+                return
+            }
+            self.phones = phoneItem
         }
     }
     
@@ -73,9 +79,12 @@ struct listReplacementView: View {
     // 入れ替えも削除も可能なリスト
     func phoneReplace(_ from: IndexSet, _ to: Int) {
         phones.move(fromOffsets: from, toOffset: to)
+        // UserDefaultsにデータを保存
+        UserDefaults.standard.set(phones, forKey: "phoneRow")
     }
     func phoneDelete(offsets: IndexSet) {
         phones.remove(atOffsets: offsets)
+        UserDefaults.standard.set(phones, forKey: "phoneRow")
     }
 }
 

--- a/swiftuiTest/listTransitionView.swift
+++ b/swiftuiTest/listTransitionView.swift
@@ -37,8 +37,8 @@ struct listTransitionView: View {
                         }
                     }
                 }
-                .navigationBarTitle("Listで画面遷移", displayMode: .inline)
             }
+            .navigationBarTitle("Listで画面遷移", displayMode: .inline)
         }
     }
 }


### PR DESCRIPTION
そのままでは順番を入れ替えたり削除をしたりしてもViewを読み込み直すと入れ替えたデータが消えてしまう。
そのため、UserDefaultsを使ってデータが保存できるようにした。
これによりViewを読み込み直しても入れ替えや削除がされた状態が維持される。