### PR TITLE
リストからの画面遷移

### DIFF
--- a/swiftuiTest/connpassList/connpassListView.swift
+++ b/swiftuiTest/connpassList/connpassListView.swift
@@ -10,13 +10,23 @@ import SwiftUI
 
 struct connpassListView: View {
     
+    @State var showModal = false
+    
 //    let events: [Event] = mockEventsData
      @ObservedObject var fetcher = StudyGroupEventFetcher()
     
     var body: some View {
         List(fetcher.eventData) { event in
-            NavigationLink(destination: connpassWebView(eventData: event)){
+//            NavigationLink(destination: connpassWebView(eventData: event)){
+//                connpassRowView(eventData: event)
+//            }
+            Button(action: {
+                self.showModal.toggle()
+            }) {
                 connpassRowView(eventData: event)
+            }
+            .sheet(isPresented: self.$showModal) {
+                connpassWebView(eventData: event)
             }
         }
     .navigationBarTitle("connpass検索結果")

--- a/swiftuiTest/connpassList/connpassWebView.swift
+++ b/swiftuiTest/connpassList/connpassWebView.swift
@@ -15,6 +15,7 @@ struct connpassWebView: View {
     
     var body: some View {
         SafariView(url: URL(string: eventData.url)!)
+            .edgesIgnoringSafeArea(.bottom)
         .navigationBarTitle(eventData.title)
     }
 }

--- a/swiftuiTest/connpassList/connpassWebView.swift
+++ b/swiftuiTest/connpassList/connpassWebView.swift
@@ -7,27 +7,28 @@
 //
 
 import SwiftUI
-import WebKit
+import SafariServices
 
 struct connpassWebView: View {
     
     var eventData: Event
     
     var body: some View {
-        WebView(loadUrl: eventData.url)
+        SafariView(url: URL(string: eventData.url)!)
         .navigationBarTitle(eventData.title)
     }
 }
 
-struct WebView: UIViewRepresentable {
-    var loadUrl:String
+struct SafariView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = SFSafariViewController
 
-    func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+    var url: URL
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        uiView.load(URLRequest(url: URL(string: loadUrl)!))
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
     }
 }
 


### PR DESCRIPTION
NavigationLinkではSafariViewでNavigationBarが二つ表示されてしまう。
また、それによりDoneボタンが動かなくなる。
そのため、画面遷移をModalとした。
今後SafariViewの前に詳細画面を挟むなどして、リストからの画面遷移をスムーズにしていくべきだと思う。